### PR TITLE
switch cli to use click, add interactive mode

### DIFF
--- a/localizer/requirements.txt
+++ b/localizer/requirements.txt
@@ -1,6 +1,7 @@
 tellopy
 av
 image
+click
 numpy>=1.21.4
 
 # https://raw.githubusercontent.com/ultralytics/yolov5/master/requirements.txt

--- a/localizer/src/cli.py
+++ b/localizer/src/cli.py
@@ -5,108 +5,137 @@ import av
 import cv2
 import numpy
 import tellopy
-from .detection import detect_objects
+import click
 
-
-def main():
-    """Drone initiation function for testing.  """
-
-    parser = argparse.ArgumentParser(description="Tello CLI")
-    parser.add_argument('command', help='foo help')
-    subparsers = parser.add_subparsers(help='sub-command help')
-
-    move = subparsers.add_parser('move', help='move help')
-    move.add_argument("direction", action="store", type=str, choices=["forward", "back", "left", "right", "up", "down"])
-
-    rotate = subparsers.add_parser('rotate', help='a help')
-    rotate.add_argument("direction", action="store", type=str, choices=["clockwise", "counter"])
-
-    takeoff = subparsers.add_parser('takeoff', help='takeoff help')
-
-    land = subparsers.add_parser('land', help='land help')
-
-    get_info = subparsers.add_parser('get_info', help='get_info help')
-
-    args = parser.parse_args()
-
-    drone = tellopy.Tello()
+@click.group()
+@click.option('--dry-run/--live', default=False)
+@click.pass_context
+def main(ctx, dry_run):
+    # ensure that ctx.obj exists and is a dict (in case `cli()` is called
+    # by means other than the `if` block below)
+    ctx.ensure_object(dict)
+    ctx.obj['DRY_RUN'] = dry_run
+    if ctx.obj['DRY_RUN']:
+        print('>> dry run mode <<')
+        return
+    ctx.obj['drone'] = tellopy.Tello()
     try:
-        drone.connect()
-        drone.wait_for_connection(60.0)
+        ctx.obj['drone'].connect()
+        ctx.obj['drone'].wait_for_connection(60.0)
     except Exception as ex:
         print(ex)
-        drone.quit()
+        ctx.obj['drone'].quit()
         return None
 
-    if args.command == 'move':
-        drone.getattr(args.direction)(1)
-    elif args.command == 'rotate':
-        if args.direction == 'clockwise':
-            drone.clockwise(90)
-        else:
-            drone.counter_clockwise(90)
-    elif args.command == 'takeoff':
-        drone.takeoff()
-    elif args.command == 'land':
-        drone.land()
-    elif args.command == 'get_info':
-        drone.subscribe(drone.EVENT_FLIGHT_DATA, lambda event, sender, data, **args: print('flight data: %s: %s' % (event.name, str(data))))
-    elif args.command == 'stream':
-        retry = 3
-        container = None
-        while container is None and 0 < retry:
-            retry -= 1
-            try:
-                container = av.open(drone.get_video_stream())
-            except av.AVError as ave:
-                print(ave)
-                print('retry...')
+@main.command()
+@click.option('--direction', nargs=1, type=click.Choice(["forward", "back", "left", "right", "up", "down"], case_sensitive=False), prompt=True)
+@click.pass_context
+def move(ctx, direction):
+    if ctx.obj['DRY_RUN']:
+        print(f'>> move {direction} <<')
+        return
+    if direction == 'forward':
+        ctx.obj['drone'].forward(0.5)
+    elif direction == 'back':
+        ctx.obj['drone'].back(0.5)
+    elif direction == 'left':
+        ctx.obj['drone'].left(0.5)
+    elif direction == 'right':
+        ctx.obj['drone'].right(0.5)
+    elif direction == 'up':
+        ctx.obj['drone'].up(0.5)
+    elif direction == 'down':
+        ctx.obj['drone'].down(0.5)
 
-        # skip first 300 frames
-        frame_skip = 300
-        while True:
-            for frame in container.decode(video=0):
-                if 0 < frame_skip:
-                    frame_skip = frame_skip - 1
-                    continue
-                start_time = time.time()
-                image = cv2.cvtColor(numpy.array(frame.to_image()), cv2.COLOR_RGB2BGR)
-                cv2.imshow('Original', image)
-                cv2.imshow('Canny', cv2.Canny(image, 100, 200))
-                cv2.waitKey(1)
-                if frame.time_base < 1.0/60:
-                    time_base = 1.0/60
-                else:
-                    time_base = frame.time_base
-                frame_skip = int((time.time() - start_time)/time_base)
-    elif args.command == 'detect':
-        retry = 3
-        container = None
-        while container is None and 0 < retry:
-            retry -= 1
-            try:
-                container = av.open(drone.get_video_stream())
-            except av.AVError as ave:
-                print(ave)
-                print('retry...')
+@main.command()
+@click.option('--direction', nargs=1, type=click.Choice(["clockwise", "counter"], case_sensitive=False), prompt=True)
+@click.pass_context
+def rotate(ctx, direction):
+    if ctx.obj['DRY_RUN']:
+        print(f'>> rotate {direction} <<')
+        return
+    if direction == 'clockwise':
+        ctx.obj['drone'].clockwise(90)
+    else:
+        ctx.obj['drone'].counter_clockwise(90)
 
-        # skip first 300 frames
-        frame_skip = 300
-        while True:
-            for frame in container.decode(video=0):
-                if 0 < frame_skip:
-                    frame_skip = frame_skip - 1
-                    continue
-                start_time = time.time()
-                image = cv2.cvtColor(numpy.array(frame.to_image()), cv2.COLOR_RGB2BGR)
-                print(f'detecting objects in frame')
-                annotated_image, detections = detect_objects(image)
-                print(f'detections: {detections}')
-                cv2.imshow("", annotated_image)     
-                cv2.waitKey(1)
-                if frame.time_base < 1.0/60:
-                    time_base = 1.0/60
-                else:
-                    time_base = frame.time_base
-                frame_skip = int((time.time() - start_time)/time_base)
-    drone.quit()
+@main.command()
+@click.pass_context
+def takeoff(ctx):
+    if ctx.obj['DRY_RUN']:
+        print('>> takeoff <<')
+        return
+    ctx.obj['drone'].takeoff()
+
+@main.command()
+@click.pass_context
+def land(ctx):
+    if ctx.obj['DRY_RUN']:
+        print('>> land <<')
+        return
+    ctx.obj['drone'].land()
+
+@main.command()
+@click.pass_context
+def query(ctx):
+    if ctx.obj['DRY_RUN']:
+        print('>> query <<')
+        return
+    ctx.obj['drone'].subscribe(ctx.obj['drone'].EVENT_FLIGHT_DATA, lambda event, sender, data, **args: print('flight data: %s: %s' % (event.name, str(data))))
+
+@main.command()
+@click.pass_context
+def stream(ctx):
+    from .detection import detect_objects
+    if ctx.obj['DRY_RUN']:
+        print('>> stream <<')
+        return
+    retry = 3
+    container = None
+    while container is None and 0 < retry:
+        retry -= 1
+        try:
+            container = av.open(ctx.obj['drone'].get_video_stream())
+        except av.AVError as ave:
+            print(ave)
+            print('retry...')
+
+    # skip first 300 frames
+    frame_skip = 300
+    while True:
+        for frame in container.decode(video=0):
+            if 0 < frame_skip:
+                frame_skip = frame_skip - 1
+                continue
+            start_time = time.time()
+            image = cv2.cvtColor(numpy.array(frame.to_image()), cv2.COLOR_RGB2BGR)
+            print(f'detecting objects in frame')
+            annotated_image, detections = detect_objects(image)
+            print(f'detections: {detections}')
+            cv2.imshow("", annotated_image)     
+            cv2.waitKey(1)
+            if frame.time_base < 1.0/60:
+                time_base = 1.0/60
+            else:
+                time_base = frame.time_base
+            frame_skip = int((time.time() - start_time)/time_base)
+
+@main.command()
+@click.pass_context
+def interactive(ctx):
+    ctx.invoke(stream)
+    while True:
+        command = click.prompt('command > ', type=str)
+        if command == 'move':
+            direction = click.prompt('| direction > ', type=click.Choice(["forward", "back", "left", "right", "up", "down"], case_sensitive=False))
+            ctx.invoke(move, direction=direction)
+        elif command == 'rotate':
+            direction = click.prompt('| direction > ', type=click.Choice(["clockwise", "counter"], case_sensitive=False))
+            ctx.invoke(rotate, direction=direction)
+        elif command == 'takeoff':
+            ctx.invoke(takeoff)
+        elif command == 'land':
+            ctx.invoke(land)
+        elif command == 'exit':
+            break
+        ctx.invoke(query)

--- a/poetry.lock
+++ b/poetry.lock
@@ -182,6 +182,17 @@ python-versions = ">=3.6.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.5"
 description = "Cross-platform colored terminal text."
@@ -1068,6 +1079,7 @@ numpy = ">=1.19.5"
 [package.source]
 type = "url"
 url = "https://pypi.anaconda.org/scipy-wheels-nightly/simple/scipy/1.10.0.dev0%2B1406.d132ca3/scipy-1.10.0.dev0%2B1406.d132ca3-cp39-cp39-macosx_12_0_arm64.whl"
+
 [[package]]
 name = "seaborn"
 version = "0.11.2"
@@ -1345,7 +1357,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "9ecb40ddd99d53d3b11f4e53ecff7233cc4baf9fcb9ea6a9f32050780da90d01"
+content-hash = "e630b45aa798b55e4d5eba5a7450be41f1fa227d8f490ea816a7ffafff072a83"
 
 [metadata.files]
 anyio = [
@@ -1406,6 +1418,10 @@ bleach = []
 certifi = []
 cffi = []
 charset-normalizer = []
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
 colorama = []
 cycler = [
     {file = "cycler-0.11.0-py3-none-any.whl", hash = "sha256:3a27e95f763a428a739d2add979fa7494c912a32c17c4c38c4d5f082cad165a3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.9"
 jupyterlab = "*"
 scipy = { url = "https://pypi.anaconda.org/scipy-wheels-nightly/simple/scipy/1.10.0.dev0%2B1406.d132ca3/scipy-1.10.0.dev0%2B1406.d132ca3-cp39-cp39-macosx_12_0_arm64.whl", markers = "platform_machine == 'aarch64'" }
 localizer = {path = "./localizer", develop = true}
+click = "^8.1.3"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
`click` is a CLI library that adds a few bells and whistles over argparse. Converted our CLI to use it, and also added an "interactive" mode as well as a "dry-run" mode.

Example:

```
$ poetry run tello --dry-run interactive
/opt/homebrew/lib/python3.9/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
>> dry run mode <<
Loading model...
Using cache found in /Users/john/.cache/torch/hub/ultralytics_yolov5_master
YOLOv5 🚀 2022-7-15 Python-3.9.13 torch-1.11.0 CPU

Fusing layers... 
YOLOv5s summary: 213 layers, 7225885 parameters, 0 gradients
Adding AutoShape... 
>> stream <<
command > : move 
| direction >  (forward, back, left, right, up, down): forward
>> move forward <<
>> query <<
command > : land
>> land <<
>> query <<
command > : takeoff
>> takeoff <<
>> query <<
command > : exit

$
```
